### PR TITLE
Minified Content Showing Up as Bytes instead of String in Python 3.6

### DIFF
--- a/django_smartstaticfiles/storage.py
+++ b/django_smartstaticfiles/storage.py
@@ -161,7 +161,9 @@ class SmartManifestFilesMixin(CachedSettingsMixin, ManifestFilesMixin):
                 try:
                     content_text = content.read()
                     if not isinstance(content_text, six.string_types):
-                        content_text.decode(settings.FILE_CHARSET)
+                        content_text = content_text.decode(
+                            settings.FILE_CHARSET
+                        )
                 finally:
                     if opened:
                         content.close()

--- a/django_smartstaticfiles/storage.py
+++ b/django_smartstaticfiles/storage.py
@@ -7,6 +7,8 @@ import posixpath
 import re
 from tempfile import NamedTemporaryFile
 
+import six
+
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files import File
@@ -157,8 +159,9 @@ class SmartManifestFilesMixin(CachedSettingsMixin, ManifestFilesMixin):
                     content = storage.open(path)
                     opened = True
                 try:
-                    # content_text = content.read().decode(settings.FILE_CHARSET)
                     content_text = content.read()
+                    if not isinstance(content_text, six.string_types):
+                        content_text.decode(settings.FILE_CHARSET)
                 finally:
                     if opened:
                         content.close()

--- a/django_smartstaticfiles/storage.py
+++ b/django_smartstaticfiles/storage.py
@@ -7,7 +7,6 @@ import posixpath
 import re
 from tempfile import NamedTemporaryFile
 
-import six
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -159,11 +158,13 @@ class SmartManifestFilesMixin(CachedSettingsMixin, ManifestFilesMixin):
                     content = storage.open(path)
                     opened = True
                 try:
-                    content_text = content.read()
-                    if not isinstance(content_text, six.string_types):
-                        content_text = content_text.decode(
+                    read_text = content.read()
+                    try:
+                        content_text = read_text.decode(
                             settings.FILE_CHARSET
                         )
+                    except AttributeError:
+                        content_text = read_text
                 finally:
                     if opened:
                         content.close()

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,7 @@ setup(
     author='Rockallite Wulf',
     author_email='rockallite.wulf@gmail.com',
     install_requires=[
-        'Django>=1.11,<1.12',
-        'six==1.11.0'
+        'Django>=1.11,<1.12'
     ],
     extras_require={
         'jsmin': ['rjsmin'],

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-smartstaticfiles',
-    version='0.3.2',
+    version='0.3.3',
     packages=find_packages(),
     include_package_data=True,
     license='BSD License',
@@ -21,6 +21,7 @@ setup(
     author_email='rockallite.wulf@gmail.com',
     install_requires=[
         'Django>=1.11,<1.12',
+        'six==1.12.0'
     ],
     extras_require={
         'jsmin': ['rjsmin'],

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     author_email='rockallite.wulf@gmail.com',
     install_requires=[
         'Django>=1.11,<1.12',
-        'six==1.12.0'
+        'six==1.11.0'
     ],
     extras_require={
         'jsmin': ['rjsmin'],


### PR DESCRIPTION
I was having issues with the minified content appearing in the wrong format in Python 3.6

This change set leverages six to test the output of the file read, and performs the decode you had commented out.  This change set unblocked me, and allowed me to use your great library.